### PR TITLE
Python 3.8 compatibility fixes

### DIFF
--- a/confidant_client/formatter.py
+++ b/confidant_client/formatter.py
@@ -134,7 +134,7 @@ def jinja_format(data, template_file):
             if not os.path.exists(template):
                 raise jinja2.TemplateNotFound(template)
             with open(template) as f:
-                source = f.read().decode('utf-8')
+                source = f.read()
             return source, template, lambda: False
 
     combined_credentials = combined_credential_pair_format(data)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ flake8==2.3.0
 # Measures code coverage and emits coverage reports
 # Licence: BSD
 # Upstream url: https://pypi.python.org/pypi/coverage
-coverage==3.7.1
+coverage==5.1
 
 # nose makes testing easier
 # License: GNU Library or Lesser General Public License (LGPL)
@@ -21,4 +21,4 @@ mock==1.0.1
 # License: MIT
 # Upstream url: https://github.com/benjaminp/six
 # Use: Python 2/3 compatiability
-six==1.10.0
+six==1.14.0


### PR DESCRIPTION
Making `confidant` python 3.8 ready.

r? @doy-stripe 
cc @stripe/cloud 